### PR TITLE
Installing nodejs on python-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM python:3.8
-# FROM python:3.8-slim
+FROM python:3.8-slim
 
-RUN apt-get update -y \
-    && apt-get upgrade -y
+WORKDIR /home/work/
+
+RUN apt-get update && apt-get upgrade
 
 # gitとかnodeとかのインストール
 # slimを使う場合はnpmの設定いらない(1行目は消す)
-RUN curl -sL https://deb.nodesource.com/setup_12.x |bash - \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     git \
     curl \
-    nodejs \
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y nodejs \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf \
@@ -29,8 +29,4 @@ RUN pip3 install --upgrade pip && \
 # slimを使う場合は最後の2行いらない
 RUN pip3 install --upgrade --no-cache-dir \
     'jupyterlab~=3.0' \
-    && rm -rf ~/.cache/pip \
-    && jupyter labextension install \
-        @jupyterlab/toc
-
-WORKDIR /home/work/
+    && rm -rf ~/.cache/pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /home/work/
 RUN apt-get update && apt-get upgrade
 
 # gitとかnodeとかのインストール
-# slimを使う場合はnpmの設定いらない(1行目は消す)
 RUN apt-get install -y --no-install-recommends \
     git \
     curl \
@@ -26,7 +25,6 @@ RUN pip3 install --upgrade pip && \
     && rm -rf ~/.cache/pip
 
 # jupyterlabとextensionのインストール
-# slimを使う場合は最後の2行いらない
 RUN pip3 install --upgrade --no-cache-dir \
     'jupyterlab~=3.0' \
     && rm -rf ~/.cache/pip


### PR DESCRIPTION
`--no-install-recommends` オプションが原因で nodejs v10 がインストールされていた
オプションを付与せず nodejs をインストールすることで解消することを確認

<img width="842" alt="スクリーンショット 2021-07-27 10 05 12" src="https://user-images.githubusercontent.com/73813661/127078703-b1de25f7-41ce-4838-93d0-76027544dd20.png">
